### PR TITLE
Add skipped tests functionality and python 2.6 compatibility 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 # coding=utf-8
+import sys
 from setuptools import setup
+
+install_requires = []
+if sys.version_info[1] < 7:
+    install_requires = ['unittest2']
 
 setup(
     name="teamcity-messages",
@@ -34,7 +39,7 @@ under TeamCity and prints usual diagnostics without it.
     ],
     url="https://github.com/JetBrains/teamcity-python",
     platforms=["any"],
-
+    install_requires=install_requires,
     packages=["teamcity"],
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@ import sys
 from setuptools import setup
 
 install_requires = []
-if sys.version_info[1] < 7:
+minor = sys.version_info[1]
+major = sys.version_info[0]
+if major < 3 and minor < 7:
     install_requires = ['unittest2']
 
 setup(

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -34,7 +34,12 @@ class TeamcityServiceMessages(object):
 
     def testFinished(self, testName, testDuration=None):
         if testDuration is not None:
-            self.message('testFinished', name=testName, duration=str(int(testDuration.total_seconds() * 1000)))
+            #added for python 2.6 compatibility
+            #(see http://docs.python.org/2.6/library/datetime.html#datetime.timedelta)
+            #(see http://docs.python.org/2.7/library/datetime.html#datetime.timedelta)
+            duration_in_seconds = (testDuration.microseconds +
+                                   (testDuration.seconds + testDuration.days * 24 * 3600) * 10**6) / 10**6
+            self.message('testFinished', name=testName, duration=str(duration_in_seconds))
         else:
             self.message('testFinished', name=testName)
 

--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -5,7 +5,9 @@ import datetime
 
 from teamcity.messages import TeamcityServiceMessages
 
-if sys.version_info[1] < 7:
+minor = sys.version_info[1]
+major = sys.version_info[0]
+if major < 3 and minor < 7:
     from unittest2 import TestResult
 else:
     from unittest import TestResult

--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -1,10 +1,15 @@
 # coding=utf-8
 import traceback
 import sys
-from unittest import TestResult
 import datetime
 
 from teamcity.messages import TeamcityServiceMessages
+
+if sys.version_info[1] < 7:
+    from unittest2 import TestResult
+else:
+    from unittest import TestResult
+
 
 def _is_string(obj):
     if sys.version_info >= (3, 0):
@@ -53,6 +58,12 @@ class TeamcityTestResult(TestResult):
 
         self.messages.testFailed(self.getTestName(test),
                                  message='Error', details=err)
+
+    def addSkip(self, test, reason):
+        TestResult.addSkip(self, test, reason)
+        self.output.write("skipped %s - %s\n" % (self.getTestName(test), reason))
+        #TODO: "testIgnored" should be replaced by "testSkipped" when implemented
+        self.messages.testIgnored(self.getTestName(test), reason)
 
     def addFailure(self, test, err, *k):
         # workaround nose bug on python 3


### PR DESCRIPTION
Hello!

There was few thing missing in the project which I add there, so if you want please pull it.

* Add python 2.6 compatibility: you were using [datetime.timedelta.total_seconds](http://docs.python.org/2.7/library/datetime.html#datetime.timedelta.total_seconds) which doesn't exist in [version 2.6](http://docs.python.org/2.6/library/datetime.html#datetime.timedelt). I also added comment in the code so please replace it if you want.
* Add notion of skipped test. As there is no message TeamcityServiceMessages.testSkipped I used TeamcityServiceMessages.testIgnored. To support that functionality in python version 2.6 need to use [unittest2](https://pypi.python.org/pypi/unittest2) (port of chnges made in python 2.7 for unittest on python 2.6). Add optional install in setup.py