### PR TITLE
Integration with nose: TypeError in addError and addFailure

### DIFF
--- a/teamcity/nose_report.py
+++ b/teamcity/nose_report.py
@@ -104,7 +104,7 @@ class TeamcityReport(object):
 
         self.messages.testFailed(test_id, message=fail_type, details=details, flowId=test_id)
 
-    def addError(self, test, err):
+    def addError(self, test, err, *k):  # nose gives 4 arguments
         test_class_name = get_class_fullname(test)
         test_id = self.get_test_id(test)
 
@@ -119,7 +119,7 @@ class TeamcityReport(object):
         else:
             self.report_fail(test, 'Error', err)
 
-    def addFailure(self, test, err):
+    def addFailure(self, test, err, *k):  # nose gives 5 arguments
         self.report_fail(test, 'Failure', err)
 
     def startTest(self, test):


### PR DESCRIPTION
I use teamcity-python with nose.
I had the following problem after upgrade package from v1.8 to v1.12:

```
Traceback (most recent call last):
  File "/envs/local/lib/python2.7/site-packages/nose/case.py", line 133, in run
    self.runTest(result)
  File "/envs/local/lib/python2.7/site-packages/nose/case.py", line 151, in runTest
    test(result)
  File "/envs/local/lib/python2.7/site-packages/django/test/testcases.py", line 184, in __call__
    super(SimpleTestCase, self).__call__(result)
  File "/usr/lib/python2.7/unittest/case.py", line 391, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    result.addFailure(self, sys.exc_info())
  File "/envs/local/lib/python2.7/site-packages/nose/proxy.py", line 146, in addFailure
    plugins.addFailure(self.test, err)
  File "/envs/local/lib/python2.7/site-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/envs/local/lib/python2.7/site-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/envs/local/lib/python2.7/site-packages/nose/plugins/manager.py", line 346, in addFailure
    return self.plugin.addFailure(test.test, err, capt, tbinfo)
TypeError: addFailure() takes exactly 3 arguments (5 given)
```

and

```
Traceback (most recent call last):
[01:59:50][Step 1/1]   File "manage.py", line 18, in <module>
[01:59:50][Step 1/1]     execute_from_command_line(sys.argv)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
[01:59:50][Step 1/1]     utility.execute()
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute
[01:59:50][Step 1/1]     self.fetch_command(subcommand).run_from_argv(self.argv)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/django/core/management/commands/test.py", line 50, in run_from_argv
[01:59:50][Step 1/1]     super(Command, self).run_from_argv(argv)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/django/core/management/base.py", line 242, in run_from_argv
[01:59:50][Step 1/1]     self.execute(*args, **options.__dict__)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/django/core/management/commands/test.py", line 71, in execute
[01:59:50][Step 1/1]     super(Command, self).execute(*args, **options)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
[01:59:50][Step 1/1]     output = self.handle(*args, **options)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/south/management/commands/test.py", line 8, in handle
[01:59:50][Step 1/1]     super(Command, self).handle(*args, **kwargs)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/django/core/management/commands/test.py", line 88, in handle
[01:59:50][Step 1/1]     failures = test_runner.run_tests(test_labels)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/django_nose/runner.py", line 218, in run_tests
[01:59:50][Step 1/1]     result = self.run_suite(nose_argv)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/django_nose/runner.py", line 165, in run_suite
[01:59:50][Step 1/1]     addplugins=plugins_to_add)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/core.py", line 121, in __init__
[01:59:50][Step 1/1]     **extra_args)
[01:59:50][Step 1/1]   File "/usr/lib/python2.7/unittest/main.py", line 95, in __init__
[01:59:50][Step 1/1]     self.runTests()
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/core.py", line 207, in runTests
[01:59:50][Step 1/1]     result = self.testRunner.run(self.test)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/core.py", line 62, in run
[01:59:50][Step 1/1]     test(result)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/suite.py", line 177, in __call__
[01:59:50][Step 1/1]     return self.run(*arg, **kw)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/suite.py", line 224, in run
[01:59:50][Step 1/1]     test(orig)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/suite.py", line 177, in __call__
[01:59:50][Step 1/1]     return self.run(*arg, **kw)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/suite.py", line 224, in run
[01:59:50][Step 1/1]     test(orig)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/case.py", line 45, in __call__
[01:59:50][Step 1/1]     return self.run(*arg, **kwarg)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/case.py", line 138, in run
[01:59:50][Step 1/1]     result.addError(self, err)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/proxy.py", line 131, in addError
[01:59:50][Step 1/1]     plugins.addError(self.test, err)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/plugins/manager.py", line 99, in __call__
[01:59:50][Step 1/1]     return self.call(*arg, **kw)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/plugins/manager.py", line 167, in simple
[01:59:50][Step 1/1]     result = meth(*arg, **kw)
[01:59:50][Step 1/1]   File "/envs/local/lib/python2.7/site-packages/nose/plugins/manager.py", line 334, in addError
[01:59:50][Step 1/1]     return self.plugin.addError(test.test, err, capt)
[01:59:50][Step 1/1] TypeError: addError() takes exactly 3 arguments (4 given)
```

I think the problem is there: ac26258e330b9bc073dc39948d275b68e261ce09

TeamCity 8.1.5
teamcity-python 1.12
nose 1.3.0, 1.3.4
django-nose 1.2, 1.3
