### PR TITLE
Make writes to output atomic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class PyTest(TestCommand):
 
 setup(
     name="teamcity-messages",
-    version="1.13",
+    version="1.14",
     author='JetBrains',
     author_email='teamcity-feedback@jetbrains.com',
     description='Send test results ' +

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class PyTest(TestCommand):
 
 setup(
     name="teamcity-messages",
-    version="1.14",
+    version="1.13",
     author='JetBrains',
     author_email='teamcity-feedback@jetbrains.com',
     description='Send test results ' +


### PR DESCRIPTION
This is for parallel test execution. It removes a few writes and instead makes 1 big write, which I believe prevents any race condition from occurring.
https://github.com/JetBrains/teamcity-python/issues/51 Is what this is in reference to.