### PR TITLE
Fix unicode encode error

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -4,8 +4,9 @@ import datetime
 
 if sys.version_info < (3, ):
     # Python 2
-    text_type = unicode
+    text_type = unicode  # flake8: noqa
 else:
+    # Python 3
     text_type = str
 
 
@@ -13,7 +14,10 @@ class TeamcityServiceMessages(object):
     quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", ']': '|]'}
 
     def __init__(self, output=sys.stdout, now=datetime.datetime.now, encoding='auto'):
-        self.output = output
+        if sys.version_info < (3, ) or not hasattr(output, 'buffer'):
+            self.output = output
+        else:
+            self.output = output.buffer
         self.now = now
 
         if getattr(output, 'encoding', None) or encoding == 'auto':

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -20,16 +20,15 @@ class TeamcityServiceMessages(object):
             self.output = output.buffer
         self.now = now
 
-        if getattr(output, 'encoding', None) or encoding == 'auto':
+        if encoding and encoding != 'auto':
+            self.encoding = encoding
+        elif getattr(output, 'encoding', None) or encoding == 'auto':
             # Default encoding to 'utf-8' because it sucks if we fail with a
             # `UnicodeEncodeError` simply because LANG didn't get propagated to
             # a subprocess or something and sys.stdout.encoding is None
-            if hasattr(output, 'encoding'):
-                self.encoding = output.encoding or 'utf-8'
-            else:
-                self.encoding = 'utf-8'
+            self.encoding = getattr(output, 'encoding', None) or 'utf-8'
         else:
-            self.encoding = encoding
+            self.encoding = None
 
     def escapeValue(self, value):
         return "".join([self.quote.get(x, x) for x in value])

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -51,6 +51,9 @@ def test_unicode():
 def test_unicode_to_sys_stdout_with_no_encoding():
     with tempfile.NamedTemporaryFile() as tmpf:
         tmpf.write(textwrap.dedent(r"""
+            import sys
+            sys.path = {sys_path}
+
             from teamcity.messages import TeamcityServiceMessages
 
             bjork = u'Bj\xf6rk Gu\xf0mundsd\xf3ttir'
@@ -58,7 +61,7 @@ def test_unicode_to_sys_stdout_with_no_encoding():
             messages = TeamcityServiceMessages()
             messages.message(bjork)
             print("hello")
-            """))
+            """.format(sys_path=sys.path)))
         tmpf.flush()
 
         ret = os.system("%s %s" % (sys.executable, tmpf.name))

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -1,5 +1,9 @@
 from teamcity.messages import TeamcityServiceMessages
 from datetime import datetime
+import os
+import sys
+import tempfile
+import textwrap
 
 
 class StreamStub(object):
@@ -42,3 +46,29 @@ def test_unicode():
     bjork = u'Bj\xf6rk Gu\xf0mundsd\xf3ttir'
     messages.message(bjork)
     assert stream.observed_output == u"\n##teamcity[%s timestamp='2000-11-02T10:23:01.556']\n" % bjork
+
+
+def test_unicode_to_sys_stdout_with_no_encoding():
+    with tempfile.NamedTemporaryFile() as tmpf:
+        tmpf.write(textwrap.dedent(r"""
+            from teamcity.messages import TeamcityServiceMessages
+
+            bjork = u'Bj\xf6rk Gu\xf0mundsd\xf3ttir'
+
+            messages = TeamcityServiceMessages()
+            messages.message(bjork)
+            print("hello")
+            """))
+        tmpf.flush()
+
+        ret = os.system("%s %s" % (sys.executable, tmpf.name))
+        assert ret == 0
+
+        # If we don't encode output, we could run into an error like this:
+        #
+        # Traceback (most recent call last):
+        #   File "/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmp5eApc3", line 7, in <module>
+        #     messages.message(bjork)
+        #   File "/Users/marca/dev/git-repos/teamcity-python/teamcity/messages.py", line 30, in message
+        #     self.output.write(message)
+        # UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 14: ordinal not in range(128)

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -45,7 +45,7 @@ def test_unicode():
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
     bjork = u'Bj\xf6rk Gu\xf0mundsd\xf3ttir'
     messages.message(bjork)
-    assert stream.observed_output == u"\n##teamcity[%s timestamp='2000-11-02T10:23:01.556']\n" % bjork
+    assert stream.observed_output == "\n##teamcity[%s timestamp='2000-11-02T10:23:01.556']\n" % bjork.encode('utf-8')
 
 
 def test_unicode_to_sys_stdout_with_no_encoding():

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -34,3 +34,11 @@ def test_three_properties():
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
     messages.message('dummyMessage', fruit='apple', meat='steak', pie='raspberry')
     assert stream.observed_output == "\n##teamcity[dummyMessage timestamp='2000-11-02T10:23:01.556' fruit='apple' meat='steak' pie='raspberry']\n"
+
+
+def test_unicode():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    bjork = u'Bj\xf6rk Gu\xf0mundsd\xf3ttir'
+    messages.message(bjork)
+    assert stream.observed_output == u"\n##teamcity[%s timestamp='2000-11-02T10:23:01.556']\n" % bjork


### PR DESCRIPTION
 Fix `UnicodeEncodeError` when `sys.stdout.encoding` is `None` and Unicode is sent -- e.g.:

```pytb
Traceback (most recent call last):
  File "/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmp5eApc3", line 7, in <module>
    messages.message(bjork)
  File "/Users/marca/dev/git-repos/teamcity-python/teamcity/messages.py", line 30, in message
    self.output.write(message)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 14: ordinal not in range(128)
```

Cc: @shalupov, @djeebus, @sudarkoff